### PR TITLE
Fix a warning which will become a hard error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ macro_rules! runcount {
         #[$($name:ident)?,$timesec:expr,$timenano:expr]
         $($lines:stmt;)*
     ) => {
-        let dur = Duration::new($timesec, $timenano)
+        let dur = Duration::new($timesec, $timenano);
         let start = Instant::now();
         let mut count = 0;
         loop {


### PR DESCRIPTION
Without this PR, the code produces a warning, which will become a hard error with rust-lang/rust#69129.